### PR TITLE
feat(version-bump): Upgrade Dockerfile for mosquitto 1.5.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,23 @@
 # Originally based on https://github.com/AnsgarSchmidt/Mosquitto
 # converted to arb64 and multistage docker build
 
-FROM arm64v8/ubuntu:16.04 as builder
+FROM arm64v8/ubuntu:18.04 as builder
 
 ARG  MOSQUITTOVERSION
-ENV  MOSQUITTOVERSION 1.4.14
+ENV  MOSQUITTOVERSION 1.5.3
 
-MAINTAINER Brett Miller <brett@shadowed.net>
+LABEL maintainer="Brett Miller <brett@shadowed.net>, Jesse Stuart <hi@jessestuart.com>"
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update   && \
-    apt-get upgrade -y && \
-    apt-get install -y wget build-essential libwrap0-dev libssl-dev python-distutils-extra \
-             libc-ares-dev uuid-dev libwebsockets-dev 
+RUN \
+  apt-get update && \
+  apt-get upgrade -y && \
+  apt-get install -y \
+    build-essential libwrap0-dev libssl-dev python-distutils-extra \
+    libc-ares-dev uuid-dev libwebsockets-dev wget
 
-RUN  mkdir -p /usr/local/src 
+RUN  mkdir -p /usr/local/src
 WORKDIR      /usr/local/src
 RUN  wget http://mosquitto.org/files/source/mosquitto-$MOSQUITTOVERSION.tar.gz && \
      tar xvzf ./mosquitto-$MOSQUITTOVERSION.tar.gz
@@ -23,16 +25,16 @@ WORKDIR /usr/local/src/mosquitto-$MOSQUITTOVERSION
 RUN make WITH_WEBSOCKETS=yes binary && mkdir /tmp/mosquitto && \
     DESTDIR=/tmp/mosquitto make install && rm -rf /tmp/mosquitto/usr/local/share
 
-FROM arm64v8/ubuntu:16.04 
+FROM arm64v8/ubuntu:18.04
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y libssl1.0.0 libc-ares2 libuuid1 libwebsockets7 && \
+    apt-get install -y libssl1.1 libc-ares2 libuuid1 libwebsockets8 && \
     apt-get clean
 RUN mkdir -p /usr/local /mosquitto/config /mosquitto/data /mosquitto/log && \
     useradd --system --no-create-home -s /usr/sbin/nologin -U mosquitto && \
     chown -R mosquitto:mosquitto /mosquitto
-COPY --from=builder /tmp/mosquitto/usr/local/ /usr/local/     
+COPY --from=builder /tmp/mosquitto/usr/local/ /usr/local/
 COPY config /mosquitto/config
 USER  mosquitto
 


### PR DESCRIPTION
The latest release at time of writing is 1.5.3.
To get this working, a few other changes were required:

- Upgrade libssl to `libssl1.1`.
- Upgrade the base image(s) to Ubuntu 18.04, since libssl1.1 isn't available in
  16.04.
- Upgrade libwebsockets7 => libwebsockets8